### PR TITLE
Simple encoding

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--require spec_helper

--- a/lib/protobuffness.rb
+++ b/lib/protobuffness.rb
@@ -1,5 +1,26 @@
 require "protobuffness/version"
+require "protobuffness/schema"
+require "protobuffness/field/string"
+require "protobuffness/wire_type"
 
 module Protobuffness
-  # Your code goes here...
+  def self.encode(values, schema)
+    stream = ::StringIO.new
+    stream.set_encoding(Encoding::BINARY)
+    values.each do |key, value|
+      field = schema.field_for(key)
+      stream << field.prefix
+      stream << field.encode(value)
+    end
+    stream.string
+  end
+
+  def self.encode_varint(value)
+    bytes = []
+    until value < 128
+      bytes << (0x80 | (value & 0x7f))
+      value >>= 7
+    end
+    (bytes << value).pack('C*')
+  end
 end

--- a/lib/protobuffness/field/string.rb
+++ b/lib/protobuffness/field/string.rb
@@ -1,0 +1,27 @@
+module Protobuffness
+  module Field
+    class String
+      attr_reader :name, :order, :rule
+
+      def initialize(rule, name, order)
+        @rule = rule
+        @name = name
+        @order = order
+      end
+
+      def prefix
+        key = (order << 3) | WireType::LENGTH_DELIMITED
+        Protobuffness.encode_varint(key)
+      end
+
+      def encode(value)
+        value_to_encode = value.dup
+        value_to_encode.encode!(Encoding::UTF_8, :invalid => :replace, :undef => :replace, :replace => "")
+        value_to_encode.force_encoding(Encoding::BINARY)
+
+        string_size = Protobuffness.encode_varint(value_to_encode.size)
+        string_size << value_to_encode
+      end
+    end
+  end
+end

--- a/lib/protobuffness/schema.rb
+++ b/lib/protobuffness/schema.rb
@@ -1,0 +1,12 @@
+module Protobuffness
+  class Schema
+    attr_reader :fields
+    def initialize(fields)
+      @fields = fields
+    end
+
+    def field_for(name)
+      fields.find{ |field| field.name == name }
+    end
+  end
+end

--- a/lib/protobuffness/wire_type.rb
+++ b/lib/protobuffness/wire_type.rb
@@ -1,0 +1,10 @@
+module Protobuffness
+  module WireType
+    VARINT           = 0
+    FIXED64          = 1
+    LENGTH_DELIMITED = 2
+    START_GROUP      = 3
+    END_GROUP        = 4
+    FIXED32          = 5
+  end
+end

--- a/spec/integration/simple_encoding_spec.rb
+++ b/spec/integration/simple_encoding_spec.rb
@@ -1,11 +1,16 @@
-RSpec.describe "encoding a very simple message" do
-  let(:schema) {
-    ::Protobuffness::Schema.new([
-      ::Protobuffness::Field::String.new(:required, :description, 1),
-    ])
-  }
-  let(:values) { {:description => "crispy"} }
-  subject { ::Protobuffness.encode(values, schema) }
+RSpec.describe "encoding very simple messages" do
+  context "single required string" do
+    let(:schema) {
+      ::Protobuffness::Schema.new([
+        ::Protobuffness::Field::String.new(:required, :description, 1),
+      ])
+    }
 
-  specify { expect(subject.encode).to eq binary_string("\n\x06crispy") }
+    def encode(description)
+      ::Protobuffness.encode({:description => description}, schema)
+    end
+
+    specify { expect(encode("bob")).to eq binary_string("\n\x03bob") }
+    specify { expect(encode("crispy")).to eq binary_string("\n\x06crispy") }
+  end
 end

--- a/spec/integration/simple_encoding_spec.rb
+++ b/spec/integration/simple_encoding_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "encoding a very simple message" do
   let(:schema) {
     ::Protobuffness::Schema.new([
-      ::Protobuffness::Field::String.new(:required, 1),
+      ::Protobuffness::Field::String.new(:required, :description, 1),
     ])
   }
   let(:values) { {:description => "crispy"} }

--- a/spec/integration/simple_encoding_spec.rb
+++ b/spec/integration/simple_encoding_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe "encoding a very simple message" do
+  let(:schema) {
+    ::Protobuffness::Schema.new([
+      ::Protobuffness::Field::String.new(:required, 1),
+    ])
+  }
+  let(:values) { {:description => "crispy"} }
+  subject { ::Protobuffness.encode(values, schema) }
+
+  specify { expect(subject.encode).to eq binary_string("\n\x06crispy") }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,3 +5,7 @@ end
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'protobuffness'
+
+def binary_string(string)
+  string.force_encoding(Encoding::BINARY)
+end


### PR DESCRIPTION
This is the simplest thing that I could think of to get started. I'm starting with the encoding because I know that the [localshred/protobuf](https://github.com/localshred/protobuf) is correct for encodings so I can easily generate test cases. I started with trying to encode a `required string description = 1` message because it has a minimal amount of things.

I haven't figured out how to represent protobuf messages as objects in ruby at all, but I am starting from the idea that there should be a lower-level abstraction made up of pure functions that take a hash of data + a schema and generates an encoded message. Later on the objects that represent protobuf messages will use this lower-level abstraction to perform their encoding, but in the meantime making the encoding process functional means that it is easier to write tests for it.

/cc @abrandoned 

I haven't even read the protocol buffers spec yet, so this is very much a stab in the dark. I'm sure the API will have a lot of churn, but feel free to poke holes in this if you see me heading down a dead-end path.
