### PR TITLE
a simplistic example of a message class

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--require spec_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+before_install: gem install bundler --no-doc
 rvm:
   - 1.9
   - 2.0

--- a/lib/protobuffness.rb
+++ b/lib/protobuffness.rb
@@ -1,4 +1,5 @@
 require "protobuffness/version"
+require "protobuffness/decoder"
 require "protobuffness/enum"
 require "protobuffness/string"
 require "protobuffness/uint32"

--- a/lib/protobuffness.rb
+++ b/lib/protobuffness.rb
@@ -1,4 +1,5 @@
 require "protobuffness/version"
+require "protobuffness/enum"
 require "protobuffness/string"
 require "protobuffness/uint32"
 require "protobuffness/wire_types"

--- a/lib/protobuffness.rb
+++ b/lib/protobuffness.rb
@@ -1,5 +1,17 @@
 require "protobuffness/version"
+require "protobuffness/string"
+require "protobuffness/uint32"
+require "protobuffness/wire_types"
 
 module Protobuffness
-  # Your code goes here...
+  module Varint
+    def self.encode(value)
+      bytes = []
+      until value < 128
+        bytes << (0x80 | (value & 0x7f))
+        value >>= 7
+      end
+      (bytes << value).pack('C*')
+    end
+  end
 end

--- a/lib/protobuffness/decoder.rb
+++ b/lib/protobuffness/decoder.rb
@@ -1,0 +1,70 @@
+module Protobuffness
+  module Decoder
+
+    # Read bytes from +stream+ and pass to +message+ object.
+    def self.decode_each_field(stream, &block)
+      until stream.eof?
+        tag, bytes = read_field(stream)
+        block.call(tag, bytes)
+      end
+    end
+
+    def self.read_field(stream)
+      tag, wire_type = read_key(stream)
+      bytes = case wire_type
+              when ::Protobuffness::WireTypes::VARINT then
+                read_varint(stream)
+              when ::Protobuffness::WireTypes::FIXED64 then
+                read_fixed64(stream)
+              when ::Protobuffness::WireTypes::LENGTH_DELIMITED then
+                read_length_delimited(stream)
+              when ::Protobuffness::WireTypes::FIXED32 then
+                read_fixed32(stream)
+              when ::Protobuffness::WireTypes::START_GROUP then
+                fail NotImplementedError, 'Group is deprecated.'
+              when ::Protobuffness::WireTypes::END_GROUP then
+                fail NotImplementedError, 'Group is deprecated.'
+              else
+                fail InvalidWireType, wire_type
+              end
+
+      [tag, bytes]
+    end
+
+    # Read 32-bit string value from +stream+.
+    def self.read_fixed32(stream)
+      stream.read(4)
+    end
+
+    # Read 64-bit string value from +stream+.
+    def self.read_fixed64(stream)
+      stream.read(8)
+    end
+
+    # Read key pair (tag and wire-type) from +stream+.
+    def self.read_key(stream)
+      bits = read_varint(stream)
+      wire_type = bits & 0x07
+      tag = bits >> 3
+      [tag, wire_type]
+    end
+
+    # Read length-delimited string value from +stream+.
+    def self.read_length_delimited(stream)
+      value_length = read_varint(stream)
+      stream.read(value_length)
+    end
+
+    # Read varint integer value from +stream+.
+    def self.read_varint(stream)
+      value = index = 0
+      begin
+        byte = stream.readbyte
+        value |= (byte & 0x7f) << (7 * index)
+        index += 1
+      end while (byte & 0x80).nonzero?
+      value
+    end
+
+  end
+end

--- a/lib/protobuffness/enum.rb
+++ b/lib/protobuffness/enum.rb
@@ -1,0 +1,16 @@
+module Protobuffness
+  module Enum
+    def self.encode(enum)
+      Varint.encode(enum.tag)
+    end
+
+    def self.encode_attribute(enum, tag)
+      encode_prefix(tag) << encode(enum)
+    end
+
+    def self.encode_prefix(tag)
+      key = (tag << 3) | WireTypes::VARINT
+      Varint.encode(key)
+    end
+  end
+end

--- a/lib/protobuffness/string.rb
+++ b/lib/protobuffness/string.rb
@@ -1,0 +1,20 @@
+module Protobuffness
+  module String
+    def self.encode(string)
+      string = string.dup
+      string.encode!(Encoding::UTF_8, :invalid => :replace, :undef => :replace, :replace => "")
+      string.force_encoding(Encoding::BINARY)
+      length = Varint.encode(string.size)
+      length << string
+    end
+
+    def self.encode_attribute(string, tag)
+      encode_prefix(tag) << encode(string)
+    end
+
+    def self.encode_prefix(tag)
+      key = (tag << 3) | WireTypes::LENGTH_DELIMITED
+      Varint.encode(key)
+    end
+  end
+end

--- a/lib/protobuffness/uint32.rb
+++ b/lib/protobuffness/uint32.rb
@@ -1,0 +1,16 @@
+module Protobuffness
+  module Uint32
+    def self.encode(value)
+      Varint.encode(value)
+    end
+
+    def self.encode_attribute(value, tag)
+      encode_prefix(tag) << encode(value)
+    end
+
+    def self.encode_prefix(tag)
+      key = (tag << 3) | WireTypes::VARINT
+      Varint.encode(key)
+    end
+  end
+end

--- a/lib/protobuffness/wire_types.rb
+++ b/lib/protobuffness/wire_types.rb
@@ -1,0 +1,10 @@
+module Protobuffness
+  module WireTypes
+    VARINT           = 0
+    FIXED64          = 1
+    LENGTH_DELIMITED = 2
+    START_GROUP      = 3
+    END_GROUP        = 4
+    FIXED32          = 5
+  end
+end

--- a/spec/enum_message_spec.rb
+++ b/spec/enum_message_spec.rb
@@ -1,0 +1,89 @@
+RSpec.describe "enum message encoding" do
+  # enum Crunchiness {
+  #   FATTY  = 0;
+  #   CRISPY = 1;
+  #   CEMENT = 2;
+  # }
+  # message Bacon {
+  #   required uint32 id = 1;
+  #   optional Crunchiness chrunchiness = 2;
+  # }
+  class Crunchiness
+    VALUES = {
+      :FATTY  => 0,
+      :CRISPY => 1,
+      :CEMENT => 2,
+    }.freeze
+
+    attr_reader :label
+
+    def initialize(label)
+      @label = label
+    end
+
+    def tag
+      VALUES[label]
+    end
+  end
+
+  class Bacon
+    def initialize(attributes)
+      @attributes = {}
+      attributes.each do |attribute, value|
+        public_send("#{attribute}=", value)
+      end
+    end
+
+    ## Attributes
+
+    def id
+      @attributes[:id]
+    end
+
+    def id=(id)
+      raise ArgumentError, "id is not a number" unless id.respond_to?(:to_i)
+      raise ArgumentError, "id is too large" unless id.to_i <= 4_294_967_295
+      raise ArgumentError, "id cannot be negative" unless id.to_i >= 0
+      @attributes[:id] = id
+    end
+
+    def crunchiness
+      @attributes[:crunchiness]
+    end
+
+    def crunchiness=(crunchiness)
+      @attributes[:crunchiness] = Crunchiness.new(crunchiness)
+    end
+
+    ## Encoding
+
+    def encode
+      stream = StringIO.new
+      stream.set_encoding(Encoding::BINARY)
+      encode_to_stream(stream)
+      stream.string
+    end
+
+    def encode_to_stream(stream)
+      stream << Protobuffness::Uint32.encode_attribute(@attributes[:id], 1)
+      unless @attributes[:crunchiness].nil?
+        stream << Protobuffness::Enum.encode_attribute(@attributes[:crunchiness], 2)
+      end
+    end
+  end
+
+  it "encodes a fatty bacon" do
+    bacon = Bacon.new(:id => 123, :crunchiness => :FATTY)
+    expect(bacon.encode).to eq binary_string("\b{\x10\x00")
+  end
+
+  it "encodes a crunchy bacon" do
+    bacon = Bacon.new(:id => 456, :crunchiness => :CRISPY)
+    expect(bacon.encode).to eq binary_string("\b\xC8\x03\x10\x01")
+  end
+
+  it "encodes a cement bacon" do
+    bacon = Bacon.new(:id => 25_432, :crunchiness => :CEMENT)
+    expect(bacon.encode).to eq binary_string("\b\xD8\xC6\x01\x10\x02")
+  end
+end

--- a/spec/enum_message_spec.rb
+++ b/spec/enum_message_spec.rb
@@ -9,20 +9,30 @@ RSpec.describe "enum message encoding" do
   #   optional Crunchiness chrunchiness = 2;
   # }
   class Crunchiness
-    VALUES = {
+    VALUES_BY_LABEL = {
       :FATTY  => 0,
       :CRISPY => 1,
       :CEMENT => 2,
     }.freeze
 
+    VALUES_BY_TAG = VALUES_BY_LABEL.invert.freeze
+
+    def self.lookup(value)
+      return value if value.is_a?(Crunchiness)
+      return new(value) if value.is_a?(Symbol)
+      label = VALUES_BY_TAG.fetch(value) { raise ArgumentError, "unknown Crunchiness value: #{value}" }
+      return new(label)
+    end
+
     attr_reader :label
 
     def initialize(label)
+      raise ArgumentError, "unkown Crunchiness value: #{label}" unless VALUES_BY_LABEL.keys.include?(label)
       @label = label
     end
 
     def tag
-      VALUES[label]
+      VALUES_BY_LABEL[label]
     end
   end
 
@@ -52,7 +62,7 @@ RSpec.describe "enum message encoding" do
     end
 
     def crunchiness=(crunchiness)
-      @attributes[:crunchiness] = Crunchiness.new(crunchiness)
+      @attributes[:crunchiness] = Crunchiness.lookup(crunchiness)
     end
 
     ## Encoding
@@ -85,5 +95,19 @@ RSpec.describe "enum message encoding" do
   it "encodes a cement bacon" do
     bacon = Bacon.new(:id => 25_432, :crunchiness => :CEMENT)
     expect(bacon.encode).to eq binary_string("\b\xD8\xC6\x01\x10\x02")
+  end
+
+  it "can specify the tag for an enum" do
+    bacon = Bacon.new(:id => 456, :crunchiness => 1)
+    expect(bacon.encode).to eq binary_string("\b\xC8\x03\x10\x01")
+  end
+
+  it "can specify an enum object" do
+    bacon = Bacon.new(:id => 456, :crunchiness => Crunchiness.new(:CRISPY))
+    expect(bacon.encode).to eq binary_string("\b\xC8\x03\x10\x01")
+  end
+
+  it "rejects fake values" do
+    expect{ Bacon.new(:crunchiness => :WAT) }.to raise_error(ArgumentError)
   end
 end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe "message encoding" do
 
     def encode
       stream = StringIO.new
+      stream.set_encoding(Encoding::BINARY)
       encode_to_stream(stream)
       stream.string
     end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe "message encoding" do
+  # message Sally {
+  #   required string mood = 1;
+  #   optional uint32 age  = 2;
+  # }
+  class Sally
+    def initialize(attributes)
+      @attributes = attributes
+    end
+
+    def encode
+      stream = StringIO.new
+      encode_to_stream(stream)
+      stream.string
+    end
+
+    def encode_to_stream(stream)
+      stream << Protobuffness::String.encode_attribute(@attributes[:mood], 1)
+      unless @attributes[:age].nil?
+        stream << Protobuffness::Uint32.encode_attribute(@attributes[:age], 2)
+      end
+    end
+  end
+
+  it "enodes an ageless Sally message" do
+    ageless = Sally.new(:mood => "happy")
+    expect(ageless.encode).to eq binary_string("\n\x05happy")
+  end
+
+  it "encodes a tween Sally message" do
+    tween = Sally.new(:mood => "poor", :age => 15)
+    expect(tween.encode).to eq binary_string("\n\x04poor\x10\x0F")
+  end
+
+  it "encodes an adult Sally message" do
+    adult = Sally.new(:mood => "slightly better", :age => 28)
+    expect(adult.encode).to eq binary_string("\n\x0Fslightly better\x10\x1C")
+  end
+end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -5,8 +5,35 @@ RSpec.describe "message encoding" do
   # }
   class Sally
     def initialize(attributes)
-      @attributes = attributes
+      @attributes = {}
+      attributes.each do |attribute, value|
+        public_send("#{attribute}=", value)
+      end
     end
+
+    ## Attributes
+
+    def age
+      @attributes[:age]
+    end
+
+    def age=(age)
+      raise ArgumentError, "age is not a number" unless age.respond_to?(:to_i)
+      raise ArgumentError, "age is too large" unless age.to_i <= 4_294_967_295
+      raise ArgumentError, "age cannot be negative" unless age.to_i >= 0
+      @attributes[:age] = age
+    end
+
+    def mood
+      @attributes[:mood]
+    end
+
+    def mood=(mood)
+      raise ArgumentError, "mood is not stringy" unless mood.respond_to?(:to_str)
+      @attributes[:mood] = mood
+    end
+
+    ## Encoding
 
     def encode
       stream = StringIO.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,3 +5,7 @@ end
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'protobuffness'
+
+def binary_string(str)
+  str.force_encoding(Encoding::BINARY)
+end


### PR DESCRIPTION
Before starting on the proto compiler, I wanted to play with a representation of a message class.
Here I am making a simple message class that has a string and a uint32 just so I can start to see the pattern of how to encode things.

The message class does not implement getters/setters or any type of validation on the attributes (yet), but I wanted to play with the idea that rather than storing a representation of the schema in the class, the `enode_to_stream` method implicitly uses the schema by encoding things in the right order.

All of the methods about encoding values are pure functions and they follow the pattern of knowing how to generate a prefix for that field as well as how to encode the value of that field.

Things I Like:
- `Sally` does not inherit from anything. It just defers to module functions for encoding support.
- The `encode_attribute` calls decompose nicely into `encode_prefix` and `encode`

/cc @abrandoned @vintagepenguin @ztoolson

Does this look like a good direction? How does it compare to #1 for readability? Do we like the idea of writing all the validations into setter methods? Or should we call validators that are part of the library?

``` ruby
def mood=(mood)
  raise ArgumentError, "not stringy" unless mood.responds_to(:to_s)
  @attributes[:mood] = mood.to_s
end
```

vs

``` ruby
def mood=(mood)
  Protobuffness::String.validate(mood)
  @attributes[:mood] = mood.to_s
end
```

vs

``` ruby
def mood=(mood)
  @attributes = ::Protobuffness::String.validate_and_coerce(mood)
end
```
